### PR TITLE
fix: apple 로그인 시 에러 수정

### DIFF
--- a/SendNow/Network/Member/RequestDTO/UpdateSearchIdRequestDTO.swift
+++ b/SendNow/Network/Member/RequestDTO/UpdateSearchIdRequestDTO.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct UpdateSearchIdRequestDTO: Codable {
     let searchID: String
-    let email: String?
-    let token: String?
+    let email: String
+    let token: String
 }

--- a/SendNow/Network/Member/Service/MemberService.swift
+++ b/SendNow/Network/Member/Service/MemberService.swift
@@ -36,7 +36,7 @@ final class MemberService {
     }
     
     func updateSearchID(with updateSearchIdDomain: UpdateSearchIdDomain, completion: @escaping(Bool)->Void) {
-        let path = updateSearchIdDomain.email == nil ? "/SendNow/updateSNSUserSearchID/" : "/SendNow/updateSNSUserSearchID/"
+        let path = updateSearchIdDomain.email.isEmpty ? "/SendNow/updateSNSUserSearchID/" : "/SendNow/updateEmailUserSearchID/"
         let updateSearchID = updateSearchIdDomain.toRequestDTO()
         networkSessionManager.urlPostMethod(path: path, encodeValue: updateSearchID) { result in
             completion(result)

--- a/SendNow/Signin/Domain/UpdateSearchIdDomain.swift
+++ b/SendNow/Signin/Domain/UpdateSearchIdDomain.swift
@@ -9,8 +9,8 @@ import Foundation
 
 struct UpdateSearchIdDomain {
     let searchID: String
-    let email: String?
-    let token: String?
+    let email: String
+    let token: String
 }
 
 extension UpdateSearchIdDomain {

--- a/SendNow/Signin/View/SigninView.swift
+++ b/SendNow/Signin/View/SigninView.swift
@@ -87,6 +87,7 @@ final class SigninView: UIView {
         button.setImage(UIImage(systemName: "apple.logo"), for: .normal)
         button.setTitle(" Apple로 계속하기", for: .normal)
         button.setTitleColor(.systemBackground, for: .normal)
+        button.tintColor = .systemBackground
         button.backgroundColor = .label
         button.titleLabel?.font = .systemFont(ofSize: 15.0, weight: .medium)
         button.layer.cornerRadius = 5.0

--- a/SendNow/Signin/ViewController/SettingSearchIDViewController.swift
+++ b/SendNow/Signin/ViewController/SettingSearchIDViewController.swift
@@ -106,7 +106,7 @@ extension SettingSearchIDViewController {
                     self?.signinViewModel.signupWithKakao(id: id)
                 case .apple:
                     guard let appleToken = self?.signinViewModel.signupWithAppleInfo?.appleToken else { return }
-                    let updateSearchIdInfo = UpdateSearchIdDomain(searchID: id, email: nil, token: appleToken)
+                    let updateSearchIdInfo = UpdateSearchIdDomain(searchID: id, email: "", token: appleToken)
                     self?.signinViewModel.updateSearchID(updateSearchIdInfo)
                 default: return
                 }
@@ -131,9 +131,12 @@ extension SettingSearchIDViewController {
         signinViewModel.isSuccessedUpdatedSearchID
             .asDriver(onErrorJustReturn: false)
             .drive(onNext: {[weak self] isSuccessedUpdatedSearchID in
-                guard isSuccessedUpdatedSearchID else { return }
-                guard let appleToken = self?.signinViewModel.signupWithAppleInfo?.appleToken else { return }
+                guard isSuccessedUpdatedSearchID,
+                      let appleToken = self?.signinViewModel.signupWithAppleInfo?.appleToken else { return }
                 self?.signinViewModel.signinWithApple(appleToken)
+                let rootViewController = MainTabBarController()
+                guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+                sceneDelegate.changeRootViewController(rootViewController, animated: true)
                 self?.navigationController?.popViewController(animated: true)
             })
             .disposed(by: disposeBag)

--- a/SendNow/Signin/ViewController/SettingSearchIDViewController.swift
+++ b/SendNow/Signin/ViewController/SettingSearchIDViewController.swift
@@ -106,8 +106,7 @@ extension SettingSearchIDViewController {
                     self?.signinViewModel.signupWithKakao(id: id)
                 case .apple:
                     guard let appleToken = self?.signinViewModel.signupWithAppleInfo?.appleToken else { return }
-                    let updateSearchIdInfo = UpdateSearchIdDomain(searchID: id, email: "", token: appleToken)
-                    self?.signinViewModel.updateSearchID(updateSearchIdInfo)
+                    self?.signinViewModel.updateSearchID(appleToken, id)
                 default: return
                 }
             })

--- a/SendNow/Signin/ViewController/SigninViewController.swift
+++ b/SendNow/Signin/ViewController/SigninViewController.swift
@@ -51,6 +51,7 @@ extension SigninViewController {
         bindSigninWithAppleButton()
         bindSigninButton()
         bindRegistrationRequired()
+        bindIsExistedSearchID()
         bindIsSuccessedSignupWithApple()
         bindIsExistedEmail()
         bindIsPasswordMatching()
@@ -111,6 +112,21 @@ extension SigninViewController {
                     sceneDelegate.changeRootViewController(rootViewController, animated: true)
                     return }
                 self?.navigationController?.pushViewController(SettingSearchIDViewController(), animated: true)
+            })
+            .disposed(by: disposeBag)
+    }
+    
+    private func bindIsExistedSearchID() {
+        signinViewModel.isExistedSearchID
+            .asDriver(onErrorJustReturn: false)
+            .drive(onNext: {[weak self] isExistedSearchID in
+                guard !isExistedSearchID else {
+                    let rootViewController = MainTabBarController()
+                    guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
+                    sceneDelegate.changeRootViewController(rootViewController, animated: true)
+                    return }
+                guard let appleMemberInfo = self?.signinViewModel.signupWithAppleInfo else { return }
+                self?.navigationController?.pushViewController(SettingSearchIDViewController(appleMemberInfo: appleMemberInfo), animated: true)
             })
             .disposed(by: disposeBag)
     }

--- a/SendNow/Signin/ViewModel/SigninViewModel.swift
+++ b/SendNow/Signin/ViewModel/SigninViewModel.swift
@@ -126,7 +126,8 @@ final class SigninViewModel {
         }
     }
     
-    func updateSearchID(_ updateSearchIdInfo: UpdateSearchIdDomain) {
+    func updateSearchID(_ appleToken: String, _ id: String) {
+        let updateSearchIdInfo = UpdateSearchIdDomain(searchID: id, email: "", token: appleToken)
         memberService.updateSearchID(with: updateSearchIdInfo) { [weak self] result in
             self?.isSuccessedUpdatedSearchID.onNext(result)
         }

--- a/SendNow/Signin/ViewModel/SigninViewModel.swift
+++ b/SendNow/Signin/ViewModel/SigninViewModel.swift
@@ -94,10 +94,6 @@ final class SigninViewModel {
     
     func signinWithApple(_ appleToken: String) {
         memberService.getAppleMemberInfo(with: appleToken) {[weak self] appleMemberInfo in
-            guard let searchID = appleMemberInfo.searchID else {
-                self?.isExistedSearchID.onNext(false)
-                return
-            }
             self?.appleMemberInformation = appleMemberInfo
             guard let appleToken = appleMemberInfo.appleToken,
                   let email = appleMemberInfo.email,
@@ -105,8 +101,15 @@ final class SigninViewModel {
                   let userID = appleMemberInfo.userID,
                   !(appleToken.isEmpty),
                   !(email.isEmpty),
-                  !(nickname.isEmpty),
-                  !(searchID.isEmpty) else { return }
+                  !(nickname.isEmpty) else { return }
+            
+            guard let searchID = appleMemberInfo.searchID,
+                  !(searchID.isEmpty) else {
+                let signupWithAppleInfo = SigninWithAppleDomain(searchID: "", nickname: nickname, email: email, appleToken: appleToken)
+                self?.signupWithAppleInfo = signupWithAppleInfo
+                self?.isExistedSearchID.onNext(false)
+                return
+            }
             UserDefaults.standard.set(userID, forKey: MemberInfoField.userID.rawValue)
             UserDefaults.standard.set(appleToken, forKey: MemberInfoField.appleToken.rawValue)
             UserDefaults.standard.set(searchID, forKey: MemberInfoField.searchID.rawValue)


### PR DESCRIPTION
애플 로그인 할 때 검색 아이디 설정 안 되어 있을 경우 처리가 제대로 안되어있었네용.. updateSearIdDomain(DTO)에서 token이랑 email을 옵셔널로 해놨드니 서버가 이해를 못하고 있었나바요 ㅠㅠ 
급하게 하느라 브랜치도 엉뚱한 곳에서 수정하고 있었네요
히히^^
귀엽게 봐주세요