### PR TITLE
✨ Disable Settlement withdrawn User

### DIFF
--- a/SendNow/GroupList/ViewController/GroupListViewController.swift
+++ b/SendNow/GroupList/ViewController/GroupListViewController.swift
@@ -151,8 +151,10 @@ extension GroupListViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let myGroupList = groupListViewModel.myGroupList,
               !myGroupList.isEmpty else { return }
-        let viewController = SettleTabViewController(groupID: myGroupList[indexPath.row].groupID,
-                                                     groupName: myGroupList[indexPath.row].groupName)
+        let viewController = SettleTabViewController(
+            groupID: myGroupList[indexPath.row].groupID,
+            groupName: myGroupList[indexPath.row].groupName,
+            isActiveSettlement: myGroupList[indexPath.row].isActive)
         viewController.hidesBottomBarWhenPushed = true
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/SendNow/GroupList/ViewController/GroupListViewController.swift
+++ b/SendNow/GroupList/ViewController/GroupListViewController.swift
@@ -150,7 +150,8 @@ extension GroupListViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let myGroupList = groupListViewModel.myGroupList,
-              !myGroupList.isEmpty else { return }
+              !myGroupList.isEmpty,
+              myGroupList.count > indexPath.row else { return }
         let viewController = SettleTabViewController(
             groupID: myGroupList[indexPath.row].groupID,
             groupName: myGroupList[indexPath.row].groupName,

--- a/SendNow/GroupList/ViewController/InvitedGroupViewController.swift
+++ b/SendNow/GroupList/ViewController/InvitedGroupViewController.swift
@@ -15,10 +15,12 @@ final class InvitedGroupViewController: BaseUIViewController {
     private let groupListViewModel: GroupListViewModel
     private let disposeBag = DisposeBag()
     
-    init(homeViewModel: HomeViewModel = HomeViewModel(
-        userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue)),
-         groupListViewModel: GroupListViewModel = GroupListViewModel(
-            userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue))) {
+    init(
+        homeViewModel: HomeViewModel = HomeViewModel(
+            userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue)),
+        groupListViewModel: GroupListViewModel = GroupListViewModel(
+            userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue))
+    ) {
         self.homeViewModel = homeViewModel
         self.groupListViewModel = groupListViewModel
         super.init(nibName: nil, bundle: nil)
@@ -35,11 +37,6 @@ final class InvitedGroupViewController: BaseUIViewController {
         addSubviews()
         setLayoutConstraintsInvitedGroupView()
         bindAll()
-    }
-    
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-//        groupListViewModel.removeSelectedFriend()
     }
     
     override var childForStatusBarStyle: UIViewController? {

--- a/SendNow/SettleGroup/ViewController/SettleView/SettleGroupViewController.swift
+++ b/SendNow/SettleGroup/ViewController/SettleView/SettleGroupViewController.swift
@@ -191,8 +191,7 @@ extension SettleGroupViewController: UICollectionViewDataSource {
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SpendingDetailCollectionViewCell.reuseIdentifier, for: indexPath) as? SpendingDetailCollectionViewCell else { return UICollectionViewCell() }
-        guard let groupExpenseInformations = settleGroupViewModel.groupExpenseInformations,
-              let groupExpenseDetailInformations = groupExpenseInformations.expenseInformations else { return cell }
+        guard let groupExpenseDetailInformations = settleGroupViewModel.groupExpenseInformations?.expenseInformations else { return cell }
         cell.setSpendingDetailCollectionViewCellLabel(groupExpenseInfo: groupExpenseDetailInformations[indexPath.row])
         return cell
     }

--- a/SendNow/SettleGroup/ViewController/SettleView/SettleGroupViewController.swift
+++ b/SendNow/SettleGroup/ViewController/SettleView/SettleGroupViewController.swift
@@ -15,12 +15,16 @@ final class SettleGroupViewController: BaseUIViewController {
     private let settleGroupViewModel: SettleGroupViewModel
     private let disposeBag = DisposeBag()
     
-    init(viewModel: SettleGroupViewModel = SettleGroupViewModel(
-        userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue)),
-         groupID: Int? = nil) {
+    init(
+        viewModel: SettleGroupViewModel = SettleGroupViewModel(
+            userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue)),
+        groupID: Int? = nil,
+        isActiveSettlement: Bool
+    ) {
         self.settleGroupViewModel = viewModel
         super.init(nibName: nil, bundle: nil)
         guard let id = groupID else { return }
+        settleGroupViewModel.setIsActiveSettlement(isActiveSettlement)
         settleGroupViewModel.setGroupID(id)
         settleGroupViewModel.loadGroupExpenseInformation()
         settleGroupViewModel.loadGroupCreatorID()
@@ -34,6 +38,7 @@ final class SettleGroupViewController: BaseUIViewController {
         super.viewDidLoad()
         configureSettleGroupView()
         addSubviews()
+        configureSettlementGroupViewState()
         setLayoutConstraintsSettleGroupView()
         notificationInvitedFriendObsever()
         bindAll()
@@ -52,6 +57,18 @@ extension SettleGroupViewController {
         settleGroupView.spendingDetailCollectionView.delegate = self
         view.backgroundColor = .secondarySystemBackground
         navigationController?.topViewController?.navigationItem.rightBarButtonItem = UIBarButtonItem(customView: settleGroupView.groupRemoveButton)
+    }
+    
+    private func configureSettlementGroupViewState() {
+        guard let isActive = settleGroupViewModel.isActiveSettlement else { return }
+        DispatchQueue.main.async {[weak self] in
+            self?.settleGroupView.spendingDetailAddButton.isHidden = !isActive
+            self?.settleGroupView.spendingDetailAddButton.isEnabled = isActive
+            self?.settleGroupView.groupRemoveButton.isHidden = !isActive
+            self?.settleGroupView.groupRemoveButton.isEnabled = isActive
+            guard !isActive else { return }
+            self?.settlementDisableAlert()
+        }
     }
     
     private func addSubviews() {
@@ -158,6 +175,13 @@ extension SettleGroupViewController {
             self?.present(alertController, animated: true)
         }
     }
+    
+    private func settlementDisableAlert() {
+        let alertController = UIAlertController(title: "바로보내", message: "현재 이 그룹에는 탈퇴한 회원이 포함되어 있어 정산 기능을 사용할 수 없습니다. 해당 그룹을 삭제 후 새로운 그룹으로 정산을 해 주세요.", preferredStyle: .alert)
+        let doneAction = UIAlertAction(title: "확인", style: .cancel) { _ in }
+        alertController.addAction(doneAction)
+        present(alertController, animated: true)
+    }
 }
 
 extension SettleGroupViewController: UICollectionViewDataSource {
@@ -168,16 +192,15 @@ extension SettleGroupViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: SpendingDetailCollectionViewCell.reuseIdentifier, for: indexPath) as? SpendingDetailCollectionViewCell else { return UICollectionViewCell() }
         guard let groupExpenseInformations = settleGroupViewModel.groupExpenseInformations,
-              let groupExpenseDetailInformations = settleGroupViewModel.groupExpenseInformations?.expenseInformations else { return cell }
+              let groupExpenseDetailInformations = groupExpenseInformations.expenseInformations else { return cell }
         cell.setSpendingDetailCollectionViewCellLabel(groupExpenseInfo: groupExpenseDetailInformations[indexPath.row])
-        guard let myExpenses = groupExpenseInformations.myExpenses,
-              let groupExpenses = groupExpenseInformations.groupExpenses else { return cell }
         return cell
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         guard let groupExpenseInformations = settleGroupViewModel.groupExpenseInformations,
-              let groupExpensDetailInformations = groupExpenseInformations.expenseInformations else { return }
+              let groupExpensDetailInformations = groupExpenseInformations.expenseInformations,
+              let isActiveSettlement = settleGroupViewModel.isActiveSettlement else { return }
         let expenseID = groupExpensDetailInformations[indexPath.row].expenseID
         let groupID = groupExpensDetailInformations[indexPath.row].groupID
         let expenseClassfication = groupExpensDetailInformations[indexPath.row].expenseClassfication
@@ -188,7 +211,8 @@ extension SettleGroupViewController: UICollectionViewDataSource {
             groupID: groupID,
             expenseClassfication: expenseClassfication,
             expenseDate: expenseDate,
-            expenseDetails: expenseDetails
+            expenseDetails: expenseDetails,
+            isActiveSettlement: isActiveSettlement
         )
         navigationController?.pushViewController(viewController, animated: true)
     }

--- a/SendNow/SettleGroup/ViewController/SpendingDetailsView/SpendingDetailsViewController.swift
+++ b/SendNow/SettleGroup/ViewController/SpendingDetailsView/SpendingDetailsViewController.swift
@@ -59,22 +59,23 @@ final class SpendingDetailsViewController: BaseUIViewController {
         return button
     }()
     
-    init(settleGroupViewModel: SettleGroupViewModel = SettleGroupViewModel(
-        userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue)),
-         expenseID: Int,
-         groupID: Int,
-         expenseClassfication: String,
-         expenseDate: String,
-         expenseDetails: String
+    init(
+        settleGroupViewModel: SettleGroupViewModel = SettleGroupViewModel(
+            userID: UserDefaults.standard.integer(forKey: MemberInfoField.userID.rawValue)),
+        expenseID: Int,
+        groupID: Int,
+        expenseClassfication: String,
+        expenseDate: String,
+        expenseDetails: String,
+        isActiveSettlement: Bool
     ) {
-        
         self.settleGroupViewModel = settleGroupViewModel
         super.init(nibName: nil, bundle: nil)
         self.settleGroupViewModel.setGroupID(groupID)
         self.settleGroupViewModel.setExpenseID(expenseID)
         self.settleGroupViewModel.selectExpenseClassfication(expenseClassfication)
         self.settleGroupViewModel.setExpenseDate(expenseDate)
-//        self.settleGroupViewModel.loadGroupMemberInformation()
+        self.settleGroupViewModel.setIsActiveSettlement(isActiveSettlement)
         self.settleGroupViewModel.loadSettlementCreatorID()
         self.settleGroupViewModel.loadExpenseDetailInformation(expenseID)
     }
@@ -87,6 +88,7 @@ final class SpendingDetailsViewController: BaseUIViewController {
         super.viewDidLoad()
         configureSpendingDetailsView()
         configureDatePicker()
+        configureSettlementGroupViewState()
         disableEditing()
         addSubviews()
         setLayoutConstraintsSpendingDetailsView()
@@ -103,13 +105,18 @@ extension SpendingDetailsViewController {
         view.backgroundColor = .secondarySystemBackground
         self.navigationItem.hidesBackButton = true
         navigationItem.leftBarButtonItem = UIBarButtonItem(customView: backButton)
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: updateButton)
         navigationItem.title = "지출 상세 내역"
     }
     
     private func configureDatePicker() {
         guard let date = settleGroupViewModel.expenseDate else { return }
         spendingDetailsView.datePicker.date = date
+    }
+    
+    private func configureSettlementGroupViewState() {
+        guard let isActive = settleGroupViewModel.isActiveSettlement,
+              isActive else { return }
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: updateButton)
     }
     
     private func disableEditing() {

--- a/SendNow/SettleGroup/ViewController/TabView/SettleTabViewController.swift
+++ b/SendNow/SettleGroup/ViewController/TabView/SettleTabViewController.swift
@@ -13,10 +13,16 @@ final class SettleTabViewController: TabmanViewController {
     private var viewControllers: [UIViewController]?
     private var tabTitle: String?
     
-    init(groupID: Int, groupName: String) {
+    init(
+        groupID: Int,
+        groupName: String,
+        isActiveSettlement: Bool
+    ) {
         super.init(nibName: nil, bundle: nil)
-        viewControllers = [SettleGroupViewController(groupID: groupID),
-                           IndividualRemmitDetailViewController(groupID: groupID)]
+        viewControllers = [SettleGroupViewController(
+            groupID: groupID,
+            isActiveSettlement: isActiveSettlement
+        ),IndividualRemmitDetailViewController(groupID: groupID)]
         tabTitle = groupName
     }
     

--- a/SendNow/SettleGroup/ViewModel/SettleGroupViewModel.swift
+++ b/SendNow/SettleGroup/ViewModel/SettleGroupViewModel.swift
@@ -22,6 +22,7 @@ enum FailedError: Error {
 final class SettleGroupViewModel {
     private let groupService: GroupService
     private let userID: Int
+    private(set) var isActiveSettlement: Bool?
     private(set) var expenseClassfication: String?
     private(set) var groupID: Int?
     private(set) var expenseID: Int?
@@ -45,6 +46,10 @@ final class SettleGroupViewModel {
     init(groupService: GroupService = GroupService(), userID: Int) {
         self.groupService = groupService
         self.userID = userID
+    }
+    
+    func setIsActiveSettlement(_ isActiveSettlement: Bool) {
+        self.isActiveSettlement = isActiveSettlement
     }
     
     func setGroupID(_ groupID: Int) {
@@ -155,6 +160,7 @@ final class SettleGroupViewModel {
                       let myExpenses = groupExpenseInfosDomain.myExpenses else {
                     self?.groupExpenseInfoSubject.onNext(.success(("0", "0")))
                     return }
+                self?.groupExpenseInformations = groupExpenseInfosDomain
                 self?.groupExpenseInfoSubject.onNext(.success((groupExpenses, myExpenses)))
             case .failure(let error):
                 self?.groupExpenseInfoSubject.onNext(.failure(error))


### PR DESCRIPTION
탈퇴한 회원 유무에 따른 정산 기능 비활성화/활성화

그룹원 중 탈퇴한 회원이 한 명이라도 있다면 그 그룹은 정산 기능을 사용하지 못 하도록 했어요
기능은 사용 못 하지만 내역은 그대로 남아 있어서 볼 수 있어요
탈퇴한 회원의 개인정보(이메일, 비밀번호, KakaoPayURL, 닉네임, 누구와 친구인지)
는 없지만, 탈퇴한 회원의 그룹 정산 내역은 남아 있어요 -> 정산 내역이 바뀌면 안 되니깐요
정산 내역에 탈퇴한 회원 닉네임, 은행정보(없앨거임), KakaoPayURL은 안 떠요