### PR TITLE
♻️ Refactor Server Error Alert Message

### DIFF
--- a/SendNow/Extension/UIViewController+.swift
+++ b/SendNow/Extension/UIViewController+.swift
@@ -28,8 +28,8 @@ extension UIViewController {
         }
     }
     
-    func serverErrorAlert() {
-        let alertController = UIAlertController(title: "바로 보내", message: "⚠️ 서비스가 일시적으로 이용 불가능합니다. 잠시후 다시 시도해 주세요.", preferredStyle: .alert)
+    func serverErrorAlert(errorContent: String? = nil) {
+        let alertController = UIAlertController(title: "바로 보내", message: "⚠️ 서비스가 일시적으로 이용 불가능합니다. 잠시후 다시 시도해 주세요.\(errorContent ?? "")", preferredStyle: .alert)
         let doneAction = UIAlertAction(title: "확인", style: .cancel)
         alertController.addAction(doneAction)
         self.present(alertController, animated: true)

--- a/SendNow/Signin/ViewController/SigninViewController.swift
+++ b/SendNow/Signin/ViewController/SigninViewController.swift
@@ -133,8 +133,8 @@ extension SigninViewController {
                     let rootViewController = MainTabBarController()
                     guard let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate else { return }
                     sceneDelegate.changeRootViewController(rootViewController, animated: true)
-                case .failure(_):
-                    self?.serverErrorAlert()
+                case .failure(let error):
+                    self?.serverErrorAlert(errorContent: error.localizedDescription)
                 }
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## Summary
- `UIViewController.serverErrorAlert()`에 `errorContent: String?` 파라미터를 추가하여, 호출부에서 상세 에러 메시지를 전달할 수 있도록 개선
- `SigninViewController`의 로그인 실패 처리에서 `error.localizedDescription`을 알럿에 함께 표시하도록 수정
- 이전에는 모든 서버 에러가 동일한 기본 문구로만 표시되어, 사용자/개발자 입장에서 실제 원인 파악이 어려웠던 문제를 해소

## Test plan
- [ ] 로그인 실패 상황을 재현하여, 기본 안내 문구 뒤에 에러 상세 메시지가 자연스럽게 이어지는지 확인
- [ ] `errorContent`를 전달하지 않는 기존 호출부에서 알럿 문구가 종전과 동일하게 노출되는지 확인
- [ ] 알럿 메시지 길이가 길어져도 레이아웃이 깨지지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)